### PR TITLE
Repair broken CHECK directives and use CHECK-LABEL to improve test failures.

### DIFF
--- a/test/CodeGen/Mips/cheri-cap-float.ll
+++ b/test/CodeGen/Mips/cheri-cap-float.ll
@@ -4,7 +4,7 @@ target datalayout = "E-p200:256:256:256-p:64:64:64-i1:8:8-i8:8:32-i16:16:32-i32:
 target triple = "cheri-unknown-freebsd"
 
 ; Function Attrs: nounwind readonly
-; CHECK: load64
+; CHECK-LABEL: load64
 define double @load64(double addrspace(200)* nocapture readonly %x) #0 {
 entry:
   ; CHECK: cld
@@ -14,7 +14,7 @@ entry:
 }
 
 ; Function Attrs: nounwind readonly
-; CHECK: load32
+; CHECK-LABEL: load32
 define float @load32(float addrspace(200)* nocapture readonly %x) #0 {
 entry:
   ; CHECK: clw
@@ -24,7 +24,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-; CHECK: store64
+; CHECK-LABEL: store64
 define void @store64(double addrspace(200)* nocapture %x, double %y) #1 {
 entry:
   ; CHECK: dmfc1
@@ -34,7 +34,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-; CHECK: store32
+; CHECK-LABEL: store32
 define void @store32(float addrspace(200)* nocapture %x, float %y) #1 {
 entry:
   ; CHECK: mfc1

--- a/test/CodeGen/Mips/cheri-intrinsics.ll
+++ b/test/CodeGen/Mips/cheri-intrinsics.ll
@@ -9,7 +9,7 @@ entry:
   %call = tail call i8* @malloc(i64 %s) nounwind
   %0 = ptrtoint i8* %call to i64
   %1 = inttoptr i64 %0 to i8 addrspace(200)*
-  ; CSetLen
+  ; CHECK: csetlen
   %2 = tail call i8 addrspace(200)* @llvm.mips.set.cap.length(i8 addrspace(200)* %1, i64 %s)
   ret i8 addrspace(200)* %2
 }
@@ -18,7 +18,7 @@ declare noalias i8* @malloc(i64) nounwind
 
 declare i8 addrspace(200)* @llvm.mips.set.cap.length(i8 addrspace(200)*, i64) nounwind readnone
 
-; CHECK: addBase
+; CHECK-LABEL: addBase
 define i8 addrspace(200)* @addBase(i8 addrspace(200)* %p) nounwind readnone {
 entry:
   ; CHECK: cincoffset
@@ -26,7 +26,7 @@ entry:
   ret i8 addrspace(200)* %incdec.ptr
 }
 
-; CHECK: getLength
+; CHECK-LABEL: getLength
 define i64 @getLength(i8 addrspace(200)* %c) nounwind readnone {
 entry:
   ; CHECK: cgetlen
@@ -36,7 +36,7 @@ entry:
 
 declare i64 @llvm.mips.get.cap.length(i8 addrspace(200)*) nounwind readnone
 
-; CHECK: getPerms
+; CHECK-LABEL: getPerms
 define signext i16 @getPerms(i8 addrspace(200)* %c) nounwind readnone {
 entry:
   ; CHECK: cgetperm
@@ -47,7 +47,7 @@ entry:
 
 declare i64 @llvm.mips.get.cap.perms(i8 addrspace(200)*) nounwind readnone
 
-; CHECK: andPerms
+; CHECK-LABEL: andPerms
 define i8 addrspace(200)* @andPerms(i8 addrspace(200)* %c, i16 signext %perms) nounwind readnone {
 entry:
   ; CHECK: candperm
@@ -58,7 +58,7 @@ entry:
 
 declare i8 addrspace(200)* @llvm.mips.and.cap.perms(i8 addrspace(200)*, i64) nounwind readnone
 
-; CHECK: gettype
+; CHECK-LABEL: gettype
 define i64 @gettype(i8 addrspace(200)* %c) nounwind readnone {
 entry:
   ; CHECK: cgettype
@@ -68,10 +68,10 @@ entry:
 
 declare i64 @llvm.mips.get.cap.type(i8 addrspace(200)*) nounwind readnone
 
-; CHECK: setType
+; CHECK-LABEL: setType
 define i8 addrspace(200)* @setType(i8 addrspace(200)* %c, i64 %type) nounwind readnone {
 entry:
-  ; CHECK csettype
+  ; CHECK: csettype
   %0 = tail call i8 addrspace(200)* @llvm.mips.set.cap.type(i8 addrspace(200)* %c, i64 %type)
   ret i8 addrspace(200)* %0
 }


### PR DESCRIPTION
Sometimes, we do `CHECK: some-procedure-name` to separate tests within the same file from each other.
While mostly fine, there are edgecases that cause this to produce slightly confusing error messages
in the event of failure, something for which FileCheck has a shiny feature for avoiding:
http://llvm.org/docs/CommandGuide/FileCheck.html#the-check-label-directive

Additionally, two typo'd CHECK directives were repaired. (one missing a colon, so it wasn't really
a CHECK, and one that was just a comment with the name of the instruction that was to be checked for).
