### PR TITLE
Correctly support ACC128

### DIFF
--- a/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -197,8 +197,11 @@ storeRegToStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
 
   unsigned Opc = 0;
 
+  // The ACC64/128 registers are handled by STORE_ACC64/128 pseudos, which call this function again with more ordinary
+  // registers when they are lowered: so no special treatment for CHERI is required.
   if (RI.Subtarget.usesCheriStackCapabilityABI() &&
-      !Mips::ACC64RegClass.hasSubClassEq(RC)) {
+      !Mips::ACC64RegClass.hasSubClassEq(RC) &&
+      !Mips::ACC128RegClass.hasSubClassEq(RC)) {
     if (Mips::GPR32RegClass.hasSubClassEq(RC))
       Opc = Mips::CAPSTORE32;
     else if (Mips::GPR64RegClass.hasSubClassEq(RC))
@@ -282,8 +285,11 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
   MachineMemOperand *MMO = GetMemOperand(MBB, FI, MachineMemOperand::MOLoad);
   unsigned Opc = 0;
 
+  // The ACC64/128 registers are handled by LOAD_ACC64/128 pseudos, which call this function again with more ordinary
+  // registers when they are lowered: so no special treatment for CHERI is required.
   if (RI.Subtarget.usesCheriStackCapabilityABI() &&
-      !Mips::ACC64RegClass.hasSubClassEq(RC)) {
+      !Mips::ACC64RegClass.hasSubClassEq(RC) &&
+      !Mips::ACC128RegClass.hasSubClassEq(RC)) {
     if (Mips::GPR32RegClass.hasSubClassEq(RC))
       Opc = Mips::CAPLOAD32;
     else if (Mips::GPR64RegClass.hasSubClassEq(RC))

--- a/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -298,9 +298,10 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
       BuildMI(MBB, I, DL, get(Mips::DMTC1), DestReg)
         .addReg(IntReg, getKillRegState(true));
       return;
-    }
-    else if (Mips::CheriRegsRegClass.hasSubClassEq(RC)) {
+    } else if (Mips::CheriRegsRegClass.hasSubClassEq(RC)) {
       Opc = Mips::LOADCAP;
+    } else {
+      llvm_unreachable("Unexpected register type for CHERI!");
     }
     BuildMI(MBB, I, DL, get(Opc), DestReg)
       .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)

--- a/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -210,7 +210,7 @@ storeRegToStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
       BuildMI(MBB, I, DL, get(Mips::DMFC1), IntReg)
         .addReg(SrcReg);
       BuildMI(MBB, I, DL, get(Mips::CAPSTORE64)).addReg(IntReg, getKillRegState(true))
-        .addFrameIndex(FI).addImm(0).addMemOperand(MMO)
+        .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
         .addReg(Mips::C11);
       return;
     }
@@ -225,7 +225,7 @@ storeRegToStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
       llvm_unreachable("Unexpected register type for CHERI!");
     }
     BuildMI(MBB, I, DL, get(Opc)).addReg(SrcReg, getKillRegState(isKill))
-      .addFrameIndex(FI).addImm(0).addMemOperand(MMO)
+      .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
       .addReg(Mips::C11);
     return;
   }
@@ -263,7 +263,7 @@ storeRegToStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
     MachineFrameInfo *MFI = MBB.getParent()->getFrameInfo();
     MFI->setObjectAlignment(FI, 32);
     BuildMI(MBB, I, DL, get(Opc)).addReg(SrcReg, getKillRegState(isKill))
-      .addFrameIndex(FI).addImm(0).addMemOperand(MMO)
+      .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
       .addReg(Mips::C0);
     return;
   }
@@ -293,7 +293,7 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
       MachineRegisterInfo &RegInfo = MBB.getParent()->getRegInfo();
       unsigned IntReg = RegInfo.createVirtualRegister(&Mips::GPR64RegClass);
       BuildMI(MBB, I, DL, get(Mips::CAPLOAD64), IntReg)
-        .addFrameIndex(FI).addImm(0).addMemOperand(MMO)
+        .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
         .addReg(Mips::C11);
       BuildMI(MBB, I, DL, get(Mips::DMTC1), DestReg)
         .addReg(IntReg, getKillRegState(true));
@@ -303,7 +303,7 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
       Opc = Mips::LOADCAP;
     }
     BuildMI(MBB, I, DL, get(Opc), DestReg)
-      .addFrameIndex(FI).addImm(0).addMemOperand(MMO)
+      .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
       .addReg(Mips::C11);
     return;
   }
@@ -336,7 +336,7 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
   else if (Mips::CheriRegsRegClass.hasSubClassEq(RC)) {
     Opc = Mips::LOADCAP;
     BuildMI(MBB, I, DL, get(Opc), DestReg)
-      .addFrameIndex(FI).addImm(0).addMemOperand(MMO)
+      .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
       .addReg(Mips::C0);
     return;
   }


### PR DESCRIPTION
We were aborting with "unexpected register type for CHERI!" for, it eventually turned out, no good reason.
The STORE/LOAD_ACC128 pseudos feed back into storeRegToStack and friends when they're lowered, so our existing CHERI-ifying logic is sufficient, we just have to stop throwing a tantrum when we see this type of register.

Fixes #96