### PR TITLE
Prevent CheriStackInvalidatePass from missing some stack spills

### DIFF
--- a/lib/Target/Mips/CheriStackInvalidatePass.cpp
+++ b/lib/Target/Mips/CheriStackInvalidatePass.cpp
@@ -91,18 +91,13 @@ namespace {
               .addFrameIndex(FI).addImm(Store->getOperand(2).getImm())
               .addMemOperand(InstrInfo->GetMemOperand(MBB, FI, MachineMemOperand::MOStore));
             DEBUG(dbgs() << "Zeroing capability spill\n");
-          } else if ((Opc == Mips::SW)    ||
-                     (Opc == Mips::SD) ||
-                     (Opc == Mips::SWC1)   ||
-                     (Opc == Mips::SDC1)  ||
-                     (Opc == Mips::SDC164)) {
+          } else {
+            // For other stores, we do the same type of store as was used for the spill, now with zeros.
             BuildMI(MBB, Ret, Ret->getDebugLoc(), InstrInfo->get(Opc))
               .addReg(Mips::ZERO)
               .addFrameIndex(FI).addImm(Store->getOperand(2).getImm())
               .addMemOperand(InstrInfo->GetMemOperand(MBB, FI, MachineMemOperand::MOStore));
-            DEBUG(dbgs() << "Zeroing integer spill\n");
-          } else {
-            DEBUG(dbgs() << "Found unsupported stack spill type\n");
+            DEBUG(dbgs() << "Zeroing non-capability spill\n");
           }
         }
       }

--- a/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -41,13 +41,9 @@ const MipsRegisterInfo &MipsSEInstrInfo::getRegisterInfo() const {
 unsigned MipsSEInstrInfo::
 isLoadFromStackSlot(const MachineInstr *MI, int &FrameIndex) const
 {
-  unsigned Opc = MI->getOpcode();
-
-  if ((Opc == Mips::LW)   || (Opc == Mips::LD)   || (Opc == Mips::LOADCAP) ||
-      (Opc == Mips::LWC1) || (Opc == Mips::LDC1) || (Opc == Mips::LDC164)) {
-    if ((MI->getOperand(1).isFI()) && // is a stack slot
-        (MI->getOperand(2).isImm()) &&  // the imm is zero
-        (isZeroImm(MI->getOperand(2)))) {
+  if (MI->mayLoad()) { // Is a load...
+    if (MI->getOperand(1).isFI() &&  // ... from a stack slot.
+        MI->getOperand(2).isImm()) {
       FrameIndex = MI->getOperand(1).getIndex();
       return MI->getOperand(0).getReg();
     }
@@ -64,17 +60,14 @@ isLoadFromStackSlot(const MachineInstr *MI, int &FrameIndex) const
 unsigned MipsSEInstrInfo::
 isStoreToStackSlot(const MachineInstr *MI, int &FrameIndex) const
 {
-  unsigned Opc = MI->getOpcode();
-
-  if ((Opc == Mips::SW)   || (Opc == Mips::SD)   || (Opc == Mips::STORECAP) ||
-      (Opc == Mips::SWC1) || (Opc == Mips::SDC1) || (Opc == Mips::SDC164)) {
-    if ((MI->getOperand(1).isFI()) && // is a stack slot
-        (MI->getOperand(2).isImm()) &&  // the imm is zero
-        (isZeroImm(MI->getOperand(2)))) {
+  if (MI->mayStore()) { // is a store...
+    if (MI->getOperand(1).isFI() && // ... to a stack slot
+        MI->getOperand(2).isImm()) {
       FrameIndex = MI->getOperand(1).getIndex();
       return MI->getOperand(0).getReg();
     }
   }
+
   return 0;
 }
 


### PR DESCRIPTION
It seems that the way things were being checked to see if they were stack spills was liable to miss some kinds of spill.