### PR TITLE
Add CHERI load/store replacement pass

### DIFF
--- a/lib/Target/Mips/CMakeLists.txt
+++ b/lib/Target/Mips/CMakeLists.txt
@@ -50,6 +50,7 @@ add_llvm_target(MipsCodeGen
   CheriAddressingModeFolder.cpp
   CheriAddressingModeFolder.cpp
   CheriBranchFolder.cpp
+  CheriLoadStoreReplacement.cpp
   CheriMemOpLowering.cpp
   CheriStackInvalidatePass.cpp
   CheriStackUglyHack.cpp

--- a/lib/Target/Mips/CheriLoadStoreReplacement.cpp
+++ b/lib/Target/Mips/CheriLoadStoreReplacement.cpp
@@ -1,0 +1,157 @@
+#include "llvm/Pass.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/Transforms/Utils/Local.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+#include <unordered_map>
+
+using namespace llvm;
+using std::pair;
+
+namespace {
+class CheriLoadStoreReplacement: public ModulePass,
+                                 public InstVisitor<CheriLoadStoreReplacement> {
+  llvm::SmallVector<LoadInst*, 16> Loads;
+  llvm::SmallVector<StoreInst*, 16> Stores;
+
+  virtual const char *getPassName() const {
+    return "CHERI MIPS load/store instruction replacement";
+  }
+
+  public:
+    static char ID;
+    CheriLoadStoreReplacement() : ModulePass(ID) {}
+
+    // InstVisitor functions to accumulate the load/store instructions found in
+    // this BB, to be batch-processed at the end (to avoid invalidating the
+    // iterator while we're using it).
+    void visitLoadInst(LoadInst &LI) {
+      // Filter out instructions that won't require introducing a cast.
+      if (LI.getPointerOperand()->getType()->getPointerAddressSpace() == 200) {
+        return;
+      }
+
+      Loads.push_back(&LI);
+    }
+    void visitStoreInst(StoreInst &SI) {
+      if (SI.getPointerOperand()->getType()->getPointerAddressSpace() == 200) {
+        return;
+      }
+
+      Stores.push_back(&SI);
+    }
+
+    virtual bool runOnModule(Module &M) override {
+      LLVMContext &C = M.getContext();
+      IRBuilder<> B(C);
+
+      // Retype all globals into address space 200.
+      for (Module::global_iterator GVI = M.global_begin(), E = M.global_end();
+           GVI != E; ) {
+        GlobalVariable *GV = GVI++;
+
+        if (GV->getType()->getPointerAddressSpace() == 200) {
+          continue;
+        }
+
+        // Build the replacement global variable. The constructor expects the
+        // pointee type (and GVs are always pointer types), hence the
+        // slightly unintuitive getContainedType call.
+        GlobalVariable *Replacement = new GlobalVariable(
+            GV->getType()->getContainedType(0), GV->isConstant(),
+            GV->getLinkage(), GV->getInitializer(), GV->getName(),
+            GV->getThreadLocalMode(), 200, GV->isExternallyInitialized());
+        Replacement->dump();
+
+        // Fixup the uses of the GV to point to the replacement. We can't
+        // use replaceAllUsesWith because the type has changed.
+        for (User *U : GV->users()) {
+          U->dump();
+          if (LoadInst *LI = dyn_cast<LoadInst>(U)) {
+            LoadInst *newInstruction = new LoadInst(Replacement, LI->getName(),
+                LI->isVolatile(), LI->getAlignment(), LI->getOrdering(),
+                LI->getSynchScope(), LI);
+
+            LI->replaceAllUsesWith(newInstruction);
+            LI->eraseFromParent();
+          } else if (StoreInst *SI = dyn_cast<StoreInst>(U)) {
+            StoreInst *newInstruction = new StoreInst(SI->getValueOperand(),
+                Replacement, SI->isVolatile(), SI->getAlignment(),
+                SI->getOrdering(), SI->getSynchScope(), SI);
+
+            SI->replaceAllUsesWith(newInstruction);
+            SI->eraseFromParent();
+          } else if (!isa<GetElementPtrInst>(U)) { // TODO: Support GEP.
+            llvm_unreachable("Unexpected global use type!");
+          }
+        }
+
+        GV->eraseFromParent();
+        M.getGlobalList().push_back(Replacement);
+      }
+
+      // Next, cast the pointer arguments of all loads/stores into addrspace
+      // 200.
+      Loads.clear();
+      Stores.clear();
+
+      visit(M);
+
+      if (Loads.empty() && Stores.empty()) {
+        return false;
+      }
+
+      for (LoadInst *LI : Loads) {
+        // Cast the pointer argument to addrspace 200.
+        Value *newLoadArgument = insertPointerArgumentCast(LI, 0, B);
+
+        // Replace the load with a new one that uses the result of the cast.
+        LoadInst *newInstruction = new LoadInst(newLoadArgument, LI->getName(),
+            LI->isVolatile(), LI->getAlignment(), LI->getOrdering(),
+            LI->getSynchScope(), LI);
+        LI->replaceAllUsesWith(newInstruction);
+        LI->eraseFromParent();
+      }
+
+      for (StoreInst *SI : Stores) {
+        Value *newStoreArgument = insertPointerArgumentCast(SI, 1, B);
+
+        StoreInst *newInstruction = new StoreInst(SI->getValueOperand(),
+            newStoreArgument, SI->isVolatile(), SI->getAlignment(),
+            SI->getOrdering(), SI->getSynchScope(), SI);
+        SI->replaceAllUsesWith(newInstruction);
+        SI->eraseFromParent();
+      }
+
+      return true;
+    }
+
+    // For a load or store instruction I, insert an address space cast for its
+    // pointer argument to addrspace 200 and return the corresponding Value.
+    Value *insertPointerArgumentCast(Instruction *I, int pointerOperandIndex, IRBuilder<> B) {
+      Value *pointerOperand = I->getOperand(pointerOperandIndex);
+
+      // Convert the pointer type to its equivalent in addrspace 200.
+      Type *pointeeType = pointerOperand->getType()->getContainedType(0);
+      PointerType *newPointerType = PointerType::get(pointeeType, 200);
+
+      // Insert an addrspace cast for the argument before instruction I and
+      // return it.
+      B.SetInsertPoint(I);
+      return B.CreateAddrSpaceCast(pointerOperand, newPointerType);
+    }
+};
+
+} // anonymous namespace
+
+char CheriLoadStoreReplacement::ID;
+
+namespace llvm {
+  ModulePass *createCheriLoadStoreReplacement(void) {
+    return new CheriLoadStoreReplacement();
+  }
+}

--- a/lib/Target/Mips/Mips.h
+++ b/lib/Target/Mips/Mips.h
@@ -40,6 +40,7 @@ namespace llvm {
   ModulePass *createCheriSandboxABI(void);
   MachineFunctionPass *createCheriAddressingModeFolder(void);
   MachineFunctionPass *createCheriBranchFolder(void);
+  BasicBlockPass *createCheriLoadStoreReplacement(void);
 } // end namespace llvm;
 
 #endif

--- a/lib/Target/Mips/MipsISelLowering.cpp
+++ b/lib/Target/Mips/MipsISelLowering.cpp
@@ -1733,7 +1733,9 @@ SDValue MipsTargetLowering::lowerGlobalAddress(SDValue Op,
     Global = getAddrGlobal(N, SDLoc(N), Ty, DAG,
                        (ABI.IsN32() || ABI.IsN64()) ? MipsII::MO_GOT_DISP
                                                     : MipsII::MO_GOT16,
-                       DAG.getEntryNode(), MachinePointerInfo::getGOT());
+                       DAG.getEntryNode(), MachinePointerInfo::getGOT(),
+                           (ABI.IsCheriSandbox() ||
+                            Subtarget.usesCheriLoadStoreReplacement()));
   if (GV->getType()->getAddressSpace() == 200)
     return DAG.getNode(ISD::INTTOPTR, SDLoc(N), AddrTy, Global);
   return Global;
@@ -2967,7 +2969,9 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
         IsCallReloc = true;
       } else {
         Callee = getAddrGlobal(G, DL, Ty, DAG, MipsII::MO_GOT_CALL, Chain,
-                               FuncInfo->callPtrInfo(Val));
+                               FuncInfo->callPtrInfo(Val),
+                               (ABI.IsCheriSandbox() ||
+                                Subtarget.usesCheriLoadStoreReplacement()));
         IsCallReloc = true;
       }
     } else
@@ -2988,7 +2992,9 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       IsCallReloc = true;
     } else { // N64 || PIC
       Callee = getAddrGlobal(S, DL, Ty, DAG, MipsII::MO_GOT_CALL, Chain,
-                             FuncInfo->callPtrInfo(Sym));
+                             FuncInfo->callPtrInfo(Sym),
+                             (ABI.IsCheriSandbox() ||
+                              Subtarget.usesCheriLoadStoreReplacement()));
       IsCallReloc = true;
     }
 

--- a/lib/Target/Mips/MipsISelLowering.h
+++ b/lib/Target/Mips/MipsISelLowering.h
@@ -301,10 +301,11 @@ namespace llvm {
     template <class NodeTy>
     SDValue getAddrGlobal(NodeTy *N, SDLoc DL, EVT Ty, SelectionDAG &DAG,
                           unsigned Flag, SDValue Chain,
-                          const MachinePointerInfo &PtrInfo) const {
+                          const MachinePointerInfo &PtrInfo,
+                          bool intToPtrWrap = false) const {
       SDValue Tgt = DAG.getNode(MipsISD::Wrapper, DL, Ty, getGlobalReg(DAG, Ty),
                                 getTargetNode(N, Ty, DAG, Flag));
-      if (ABI.IsCheriSandbox())
+      if (intToPtrWrap)
         Tgt = DAG.getNode(ISD::INTTOPTR, DL, MVT::iFATPTR, Tgt);
       return DAG.getLoad(Ty, DL, Chain, Tgt, PtrInfo, false, false, false, 0);
     }

--- a/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -192,9 +192,12 @@ storeRegToStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
 
   // The ACC64/128 registers are handled by STORE_ACC64/128 pseudos, which call this function again with more ordinary
   // registers when they are lowered: so no special treatment for CHERI is required.
-  if (Subtarget.usesCheriStackCapabilityABI() &&
+  if ((Subtarget.usesCheriStackCapabilityABI() ||
+       Subtarget.usesCheriLoadStoreReplacement()) &&
       !Mips::ACC64RegClass.hasSubClassEq(RC) &&
       !Mips::ACC128RegClass.hasSubClassEq(RC)) {
+    unsigned capabilityRegister =
+        Subtarget.usesCheriLoadStoreReplacement() ? Mips::C0 : Mips::C11;
     if (Mips::GPR32RegClass.hasSubClassEq(RC))
       Opc = Mips::CAPSTORE32;
     else if (Mips::GPR64RegClass.hasSubClassEq(RC))
@@ -206,7 +209,7 @@ storeRegToStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
         .addReg(SrcReg);
       BuildMI(MBB, I, DL, get(Mips::CAPSTORE64)).addReg(IntReg, getKillRegState(true))
         .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
-        .addReg(Mips::C11);
+        .addReg(capabilityRegister);
       return;
     }
     else if (Mips::CheriRegsRegClass.hasSubClassEq(RC)) {
@@ -221,7 +224,7 @@ storeRegToStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
     }
     BuildMI(MBB, I, DL, get(Opc)).addReg(SrcReg, getKillRegState(isKill))
       .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
-      .addReg(Mips::C11);
+      .addReg(capabilityRegister);
     return;
   }
   if (Mips::GPR32RegClass.hasSubClassEq(RC))
@@ -279,9 +282,12 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
 
   // The ACC64/128 registers are handled by LOAD_ACC64/128 pseudos, which call this function again with more ordinary
   // registers when they are lowered: so no special treatment for CHERI is required.
-  if (Subtarget.usesCheriStackCapabilityABI() &&
+  if ((Subtarget.usesCheriLoadStoreReplacement() ||
+      Subtarget.usesCheriStackCapabilityABI()) &&
       !Mips::ACC64RegClass.hasSubClassEq(RC) &&
       !Mips::ACC128RegClass.hasSubClassEq(RC)) {
+    unsigned capabilityRegister =
+        Subtarget.usesCheriLoadStoreReplacement() ? Mips::C0 : Mips::C11;
     if (Mips::GPR32RegClass.hasSubClassEq(RC))
       Opc = Mips::CAPLOAD32;
     else if (Mips::GPR64RegClass.hasSubClassEq(RC))
@@ -291,7 +297,7 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
       unsigned IntReg = RegInfo.createVirtualRegister(&Mips::GPR64RegClass);
       BuildMI(MBB, I, DL, get(Mips::CAPLOAD64), IntReg)
         .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
-        .addReg(Mips::C11);
+        .addReg(capabilityRegister);
       BuildMI(MBB, I, DL, get(Mips::DMTC1), DestReg)
         .addReg(IntReg, getKillRegState(true));
       return;
@@ -302,7 +308,7 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
     }
     BuildMI(MBB, I, DL, get(Opc), DestReg)
       .addFrameIndex(FI).addImm(Offset).addMemOperand(MMO)
-      .addReg(Mips::C11);
+      .addReg(capabilityRegister);
     return;
   }
   if (Mips::GPR32RegClass.hasSubClassEq(RC))

--- a/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -200,7 +200,6 @@ storeRegToStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
     else if (Mips::GPR64RegClass.hasSubClassEq(RC))
       Opc = Mips::CAPSTORE64;
     else if (Mips::FGR64RegClass.hasSubClassEq(RC)) {
-      DebugLoc DL = I->getDebugLoc();
       MachineRegisterInfo &RegInfo = MBB.getParent()->getRegInfo();
       unsigned IntReg = RegInfo.createVirtualRegister(&Mips::GPR64RegClass);
       BuildMI(MBB, I, DL, get(Mips::DMFC1), IntReg)
@@ -288,7 +287,6 @@ loadRegFromStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
     else if (Mips::GPR64RegClass.hasSubClassEq(RC))
       Opc = Mips::CAPLOAD64;
     else if (Mips::FGR64RegClass.hasSubClassEq(RC)) {
-      DebugLoc DL = I->getDebugLoc();
       MachineRegisterInfo &RegInfo = MBB.getParent()->getRegInfo();
       unsigned IntReg = RegInfo.createVirtualRegister(&Mips::GPR64RegClass);
       BuildMI(MBB, I, DL, get(Mips::CAPLOAD64), IntReg)

--- a/lib/Target/Mips/MipsSubtarget.cpp
+++ b/lib/Target/Mips/MipsSubtarget.cpp
@@ -59,8 +59,18 @@ CheriStackCapabilityABI(
   cl::desc("CHERI: Stack pointer is capability-relative."),
   cl::init(false));
 
+static cl::opt<bool>
+CheriLoadStoreReplacement(
+  "cheri-load-store-replacement", cl::NotHidden,
+  cl::desc("CHERI: MIPS loads/store operands are cast into addrspace 200."),
+  cl::init(false));
+
 bool MipsSubtarget::usesCheriStackCapabilityABI() const {
   return CheriStackCapabilityABI || isABI_CheriSandbox();
+}
+
+bool MipsSubtarget::usesCheriLoadStoreReplacement() const {
+  return CheriLoadStoreReplacement;
 }
 
 static cl::opt<bool>

--- a/lib/Target/Mips/MipsSubtarget.h
+++ b/lib/Target/Mips/MipsSubtarget.h
@@ -242,6 +242,7 @@ public:
   bool isCheri128() const { return IsCheri128; }
   /// Uses the ABI where the stack pointer is relative to C11, not C0.
   bool usesCheriStackCapabilityABI() const;
+  bool usesCheriLoadStoreReplacement() const;
   /// This is a very ugly hack.  CodeGenPrepare can sink pointer arithmetic to
   /// appear closer to load and store operations (because SelectionDAG only
   /// looks at one basic block at a time).  Unfortunately, it defaults to using

--- a/lib/Target/Mips/MipsTargetMachine.cpp
+++ b/lib/Target/Mips/MipsTargetMachine.cpp
@@ -224,6 +224,9 @@ public:
   void addMachineSSAOptimization() override;
   void addPreEmitPass() override;
 
+protected:
+  virtual bool addPreISel() override;
+
   void addPreRegAlloc() override;
 
 };
@@ -296,4 +299,10 @@ void MipsPassConfig::addPreEmitPass() {
   addPass(createMipsDelaySlotFillerPass(TM));
   addPass(createMipsLongBranchPass(TM));
   addPass(createMipsConstantIslandPass(TM));
+}
+
+bool MipsPassConfig::addPreISel() {
+  if (getMipsSubtarget().usesCheriLoadStoreReplacement())
+    addPass(createCheriLoadStoreReplacement());
+  return true;
 }


### PR DESCRIPTION
Adds a compiler pass to replace MIPS load/store instructions with CHERI ones.
