### PR TITLE
[MC] Add command-line option to choose the max nest level in asm macros.

### DIFF
--- a/test/MC/AsmParser/macro-max-depth.s
+++ b/test/MC/AsmParser/macro-max-depth.s
@@ -1,0 +1,20 @@
+// RUN: llvm-mc -triple x86_64-unknown-unknown -asm-macro-max-nesting-depth=42 %s | FileCheck %s -check-prefix=CHECK_PASS
+// RUN: not llvm-mc -triple x86_64-unknown-unknown %s 2> %t
+// RUN: FileCheck -check-prefix=CHECK_FAIL < %t %s
+
+.macro rec head, tail:vararg
+ .ifnb \tail
+ rec \tail
+ .else
+ .long 42
+ .endif
+.endm
+
+.macro amplify macro, args:vararg
+ \macro  \args \args \args \args
+.endm
+
+amplify rec 0 0 0 0 0 0 0 0 0 0
+
+// CHECK_PASS: .long 42
+// CHECK_FAIL: error: macros cannot be nested more than {{[0-9]+}} levels deep. Use -asm-macro-max-nesting-depth to increase this limit.


### PR DESCRIPTION
From upstream https://github.com/llvm-mirror/llvm/commit/8a6d1ad936774252240f9b8425d4d04a8a504ca3