### PR TITLE
Backport upstream r262213 (fixes assertion failure assembling _setjmp.S)

### DIFF
--- a/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -2634,7 +2634,8 @@ bool MipsAsmParser::expandBranchImm(MCInst &Inst, SMLoc IDLoc,
   assert(ImmOp.isImm() && "expected immediate operand kind");
 
   const MCOperand &MemOffsetOp = Inst.getOperand(2);
-  assert(MemOffsetOp.isImm() && "expected immediate operand kind");
+  assert((MemOffsetOp.isImm() || MemOffsetOp.isExpr()) &&
+         "expected immediate or expression operand");
 
   unsigned OpCode = 0;
   switch(Inst.getOpcode()) {

--- a/test/MC/Mips/mips-expansions.s
+++ b/test/MC/Mips/mips-expansions.s
@@ -131,6 +131,12 @@
 # CHECK-LE: beq   $2, $1, 1332      # encoding: [0x4d,0x01,0x41,0x10]
 # CHECK-LE: nop                     # encoding: [0x00,0x00,0x00,0x00]
 
+  beq $2, 65538, foo
+# CHECK-LE: lui   $1, 1             # encoding: [0x01,0x00,0x01,0x3c]
+# CHECK-LE: ori   $1, $1, 2         # encoding: [0x02,0x00,0x21,0x34]
+# CHECK-LE: beq   $2, $1, foo       # encoding: [A,A,0x41,0x10]
+# CHECK-LE: nop                     # encoding: [0x00,0x00,0x00,0x00]
+
 # Test ULH with immediate operand.
 ulh_imm: # CHECK-LABEL: ulh_imm:
   ulh $8, 0

--- a/test/MC/Mips/mips64-expansions.s
+++ b/test/MC/Mips/mips64-expansions.s
@@ -145,6 +145,17 @@
 # CHECK: beq  $2, $1, 1332          # encoding: [0x4d,0x01,0x41,0x10]
 # CHECK: nop                        # encoding: [0x00,0x00,0x00,0x00]
 
+# Test one with a symbol in the third operand.
+sym:
+  bne $2, 0x100010001, sym
+# CHECK: addiu $1, $zero, 1         # encoding: [0x01,0x00,0x01,0x24]
+# CHECK: dsll $1, $1, 16            # encoding: [0x38,0x0c,0x01,0x00]
+# CHECK: ori  $1, $1, 1             # encoding: [0x01,0x00,0x21,0x34]
+# CHECK: dsll $1, $1, 16            # encoding: [0x38,0x0c,0x01,0x00]
+# CHECK: ori  $1, $1, 1             # encoding: [0x01,0x00,0x21,0x34]
+# CHECK: bne  $2, $1, sym           # encoding: [A,A,0x41,0x14]
+# CHECK: nop                        # encoding: [0x00,0x00,0x00,0x00]
+
 # Test ulhu with 64-bit immediate addresses.
   ulhu $8, 0x100010001
 # CHECK: addiu $1, $zero, 1    # encoding: [0x01,0x00,0x01,0x24]


### PR DESCRIPTION
Using LLVM's as for buildworld fails on _setjmp.S:

````
Assertion failed: (MemOffsetOp.isImm() && "expected immediate operand kind"), function expandBranchImm, file ../lib/Target/Mips/AsmParser/MipsAsmParser.cpp, line 2637.
clang-3.8: error: unable to execute command: Abort trap (core dumped)
clang-3.8: error: clang integrated assembler command failed due to signal (use -v to see invocation)
clang version 3.8.0 (git@github.com:CTSRD-CHERI/clang 05f124e1657de7fd881aec2ad65f265f657b1edb) (git@github.com:CTSRD-CHERI/llvm 471fd36fd68c027e3755ea928aa03defe762448c)
Target: cheri-unknown-freebsd
Thread model: posix
InstalledDir: /home/james/src/cheri/llvm/Build/bin
````

This is because of the `bne v0, 0xACEDBADE, botch # jump if error`, which of course does not have an immediate for the third operand, and was fixed upstream in http://llvm.org/viewvc/llvm-project?view=revision&revision=262213, but not backported to the 3.8 branch.