### PR TITLE
Miscellaneous fixes for buildworld

### DIFF
--- a/lib/Target/Mips/MipsISelLowering.cpp
+++ b/lib/Target/Mips/MipsISelLowering.cpp
@@ -1872,10 +1872,10 @@ SDValue MipsTargetLowering::lowerGlobalAddress(SDValue Op,
         !GV->hasSection() &&
         !Name.startswith("__start_") &&
         !Name.startswith("__stop_")) {
-      uint64_t SizeBytes = DAG.getDataLayout().getTypeAllocSize(GV->getValueType());
-      if (GV->hasInternalLinkage() || GV->hasLocalLinkage())
+      if (GV->hasInternalLinkage() || GV->hasLocalLinkage()) {
+        uint64_t SizeBytes = DAG.getDataLayout().getTypeAllocSize(GV->getValueType());
         Global = setBounds(DAG, Global, SizeBytes);
-      else {
+      } else {
         const Module &M = *GV->getParent();
         std::string Name = (Twine(".size.")+GV->getName()).str();
         GlobalVariable *SizeGV = M.getGlobalVariable(Name);

--- a/lib/Transforms/Scalar/GVN.cpp
+++ b/lib/Transforms/Scalar/GVN.cpp
@@ -1381,9 +1381,12 @@ Value *AvailableValueInBlock::MaterializeAdjustedValue(LoadInst *LI,
             gvn.getTargetLibraryInfo());
         // If we don't know the size of the underlying object then we can't
         // assume that we can look through this pointer.
-        if (!KnownSize)
-          Size = DL.getTypeStoreSize(cast<PointerType>(Object->getType())
-              ->getElementType());
+        if (!KnownSize) {
+          Type *ElemTy = cast<PointerType>(Object->getType())->getElementType();
+          if (!ElemTy->isSized())
+            return LI;
+          Size = DL.getTypeStoreSize(ElemTy);
+        }
         unsigned LoadSize = DL.getTypeStoreSize(LoadTy);
         unsigned SrcValSize = DL.getTypeStoreSize(Load->getType());
         if ((Offset+LoadSize > SrcValSize) && (NextPowerOf2(Offset)+LoadOffset > Size))

--- a/test/CodeGen/Mips/cheri-sandbox-vaargs2.ll
+++ b/test/CodeGen/Mips/cheri-sandbox-vaargs2.ll
@@ -1,0 +1,42 @@
+; RUN: clang -cc1 -triple cheri-unknown-bsd -cheri-linker -target-abi sandbox -O2 -S -o - %s | FileCheck %s
+; ModuleID = 'libxo.i'
+target datalayout = "E-m:m-pf200:256:256-i8:8:32-i16:16:32-i64:64-n32:64-S128-A200"
+target triple = "cheri-unknown-bsd"
+
+%struct.xo_handle_s = type { i8 addrspace(200)* }
+
+@b = common addrspace(200) global %struct.xo_handle_s zeroinitializer, align 32
+
+; Function Attrs: nounwind
+; CHECK-LABEL: xo_emit:
+; Check that locally creating a va_list and then storing it to a global works
+; (Yes, this is an odd thing to do.  See libxo for a real-world example)
+; This is similar to cheri-sandbox-vaargs.ll, but ensures CheriSandboxABI can
+; handle the optimiser turning AddrSpaceCast instructions into ConstantExpr's
+define void @xo_emit(i8 addrspace(200)* %fmt, ...) #0 {
+entry:
+  %fmt.addr = alloca i8 addrspace(200)*, align 32
+  %c = alloca %struct.xo_handle_s addrspace(200)*, align 32
+  store i8 addrspace(200)* %fmt, i8 addrspace(200)* addrspace(200)* %fmt.addr, align 32
+  store %struct.xo_handle_s addrspace(200)* @b, %struct.xo_handle_s addrspace(200)* addrspace(200)* %c, align 32
+  %0 = load %struct.xo_handle_s addrspace(200)*, %struct.xo_handle_s addrspace(200)* addrspace(200)* %c, align 32
+  %xo_vap = getelementptr inbounds %struct.xo_handle_s, %struct.xo_handle_s addrspace(200)* %0, i32 0, i32 0
+  %xo_vap1 = addrspacecast i8 addrspace(200)* addrspace(200)* %xo_vap to i8*
+  ; Load the address of b
+  ; CHECK: ld	$1, %got_disp(b)($1)
+  ; CHECK: cfromptr $c1, $c0, $1
+  ; Store the va_list (passed in $c13) in the global
+  ; CHECK: csc	$c13, $zero, 0($c1)
+  call void @llvm.va_start(i8* %xo_vap1)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @llvm.va_start(i8*) #1
+
+attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-features"="+cheri" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind }
+
+!llvm.ident = !{!0}
+
+!0 = !{!"clang version 3.8.0 (git@github.com:CTSRD-CHERI/clang 05f124e1657de7fd881aec2ad65f265f657b1edb) (git@github.com:CTSRD-CHERI/llvm daf436f19e3bee85398590f0e29ed5981de61c14)"}

--- a/test/CodeGen/Mips/cheri-unsized-unresolved-extern.ll
+++ b/test/CodeGen/Mips/cheri-unsized-unresolved-extern.ll
@@ -1,0 +1,35 @@
+; RUN: clang -cc1 -triple cheri-unknown-bsd -cheri-linker -target-abi sandbox -O2 -S -o - %s | FileCheck %s
+; ModuleID = 'ocsp_cl.i'
+target datalayout = "E-m:m-pf200:256:256-i8:8:32-i16:16:32-i64:64-n32:64-S128-A200"
+target triple = "cheri-unknown-bsd"
+
+%struct.ASN1_ITEM_st = type opaque
+
+@a = external addrspace(200) global %struct.ASN1_ITEM_st, align 1
+
+; Function Attrs: nounwind
+; CHECK-LABEL: fn1:
+; Check that clang doesn't try to get the size of struct.ASN1_ITEM_st, since
+; it's not known and does not need to be
+define void @fn1() #0 {
+entry:
+  ; Load the address of a
+  ; CHECK: ld	$2, %got_disp(a)($gp)
+  ; CHECK: cfromptr $c1, $c0, $2
+  ; Call fn2
+  ; CHECK: ld	$1, %call16(fn2)($gp)
+  ; CHECK: cgetpccsetoffset	$c12, $1
+  ; CHECK: cjalr	$c12, $c17
+  tail call void @fn2(%struct.ASN1_ITEM_st addrspace(200)* @a) #2
+  ret void
+}
+
+declare void @fn2(%struct.ASN1_ITEM_st addrspace(200)*) #1
+
+attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-features"="+cheri" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-features"="+cheri" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!llvm.ident = !{!0}
+
+!0 = !{!"clang version 3.8.0 (git@github.com:CTSRD-CHERI/clang) (git@github.com:CTSRD-CHERI/llvm 3d829d6649fd95c68a8460232114f17efafc02bd)"}

--- a/test/Transforms/GVN/cheri-gvn-unsized.c
+++ b/test/Transforms/GVN/cheri-gvn-unsized.c
@@ -1,0 +1,48 @@
+// RUN: clang -cc1 -triple cheri-unknown-bsd -cheri-linker -target-abi sandbox -O2 -S -o - %s | FileCheck %s
+// ModuleID = 'ocsp_cl.i'
+// GVN was seen to unconditionally get the size of the underlying type for a
+// pointer when it was unsized.
+// This needs to be as C source rather than LLVM IR, since the assertion that
+// was hit with this test case is reached when generating the IR itself.
+typedef struct { void *qualifiers; } POLICYINFO;
+struct SOMETHING_ELSE *fn2();
+POLICYINFO *a;
+POLICYINFO *b;
+typedef struct stack_st stack_st;
+void sk_push(stack_st *);
+// CHECK-LABEL: fn1:
+void fn1() {
+  // Call fn2
+  // CHECK: ld	$1, %call16(fn2)($gp)
+  // CHECK: cgetpccsetoffset	$c12, $1
+  // CHECK: cjalr	$c12, $c17
+  // Load address of a
+  // CHECK: ld	$2, %got_disp(a)($gp)
+  // CHECK: cfromptr	$c1, $c0, $2
+  // Store in a
+  // CHECK: csc	$c3, $zero, 0($c1)
+  a = (POLICYINFO *__capability)fn2();
+  // Load address of b
+  // CHECK: ld	$2, %got_disp(b)($gp)
+  // CHECK: cfromptr	$c1, $c0, $2
+  // Store in b
+  // CHECK: csc	$c3, $zero, 0($c2)
+  b = a;
+  // Load qualifiers
+  // CHECK: clc	$c1, $zero, 0($c3)
+  // Create NULL capability
+  // CHECK: cfromptr	$c4, $c0, $zero
+  // Check if qualifiers is NULL
+  // CHECK: ceq	$1, $c1, $c4
+  // CHECK: bnez	$1, $BB0_2
+  if (b->qualifiers)
+    // Store above NULL capability in qualifiers
+    // CHECK: csc	$c4, $zero, 0($c3)
+    b->qualifiers = 0;
+  // CHECK-LABEL: $BB0_2:
+  // Call sk_push
+  // CHECK: ld	$1, %call16(sk_push)($gp)
+  // CHECK: cgetpccsetoffset	$c12, $1
+  // CHECK: cjalr	$c12, $c17
+  sk_push((stack_st *)b->qualifiers);
+}


### PR DESCRIPTION
With the following patches (each of which has a testcase based on the file which caused buildworld to die), I have been able to run a full buildworld with the default optimisation level, with the exception of cheritest_register.c, where I ran into #133 and patched it instead to use cheri_getreg(11).