### PR TITLE
Fix CFromPtr32 operand order

### DIFF
--- a/lib/Target/Mips/MipsInstrCheri.td
+++ b/lib/Target/Mips/MipsInstrCheri.td
@@ -291,7 +291,7 @@ def CToPtr : CheriFmtRegs<0xc, 0, (outs GPR64Opnd: $r0),
   "ctoptr $r0, $r1, $r2", [(set GPR64Opnd: $r0, (int_cheri_cap_to_pointer CheriOpnd: $r2, CheriOpnd: $r1))]>;
 let isCodeGenOnly = 1 in {
 def CFromPtr32 : CheriFmtRegs<4, 7, (outs CheriOpnd: $r0),
-  (ins CheriOpnd: $r2, GPR32Opnd: $r1),
+  (ins CheriOpnd: $r1, GPR32Opnd: $r2),
   "cfromptr\t$r0, $r1, $r2", []>;
 def CToPtr32 : CheriFmtRegs<0xc, 0, (outs GPR32Opnd: $r0),
   (ins CheriOpnd: $r2, CheriOpnd: $r1),


### PR DESCRIPTION
This was seen to break:

    strchr("123456789", *p) != NULL;

as it would end up generating something like:

    cfromptr $c1, $1, $c0

which would end up as:

    cfromptr $c1, $c1, $zero

causing the result to always be NULL and giving false.

This should fix the cause behind [this CheriBSD commit](https://github.com/CTSRD-CHERI/cheribsd/commit/b9d7ba37485b7a6c433fd527e7e4253b320e1654).